### PR TITLE
Bugfix: PESummary conversion to bilby json

### DIFF
--- a/pesummary/core/file/formats/pesummary.py
+++ b/pesummary/core/file/formats/pesummary.py
@@ -540,7 +540,7 @@ class PESummary(MultiAnalysisRead):
             elif isinstance(filenames, dict):
                 filename = filenames[label]
             else:
-                filename = filenames
+                filename = filenames[num]
 
             if _config or kwargs.get("file_format", "dat") == "ini":
                 kwargs["file_format"] = "ini"


### PR DESCRIPTION
Bugfix: On the current master branch, the following doesn't work:
```
import pesummary.io
filename = "pedata/IGWN-GWTC3p0-v1-GW191103_012549_PEDataRelease_mixed_nocosmo.h5"
pesummary.io.read(filename)
data = pesummary.io.read(filename)
labels   = ["C01:IMRPhenomXPHM", "C01:Mixed", "C01:SEOBNRv4PHM"]
filenames_to_save= ["pedata/IGWN-GWTC3p0-v1-GW191103_012549_PEDataRelease_mixed_nocosmo_%s.json"%label for label in labels]
bilby_result = data.to_bilby(filenames=filenames_to_save)
```
If the user tries to input "filename" to the `to_bilby` write function, pesummary states that it is not supported and that the user should instead provide a list of filenames. However, this functionality does not work correctly. In particular, the code should be iterating over the different labels and assigning each Bilby run in the pesummary file a filename from the "filenames" list (i.e., filename=filenames[num]). Instead, the current code assigns filename=filenames. So I'm submitting
a bugfix.